### PR TITLE
Proposition to remove nowrap class

### DIFF
--- a/administrator/components/com_content/views/articles/tmpl/default.php
+++ b/administrator/components/com_content/views/articles/tmpl/default.php
@@ -170,7 +170,7 @@ $assoc		= JLanguageAssociations::isEnabled();
 							<?php echo JHtml::_('contentadministrator.featured', $item->featured, $i, $canChange); ?>
 						</div>
 					</td>
-					<td class="nowrap has-context">
+					<td class="has-context">
 						<div class="pull-left">
 							<?php if ($item->checked_out) : ?>
 								<?php echo JHtml::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time, 'articles.', $canCheckin); ?>


### PR DESCRIPTION
Hi to all!
When a very long title, nowrap class (white-space: nowrap), gives a view of the list of articles outside screen.
Not really interresting in a responsive design.
I may be wrong about the reason of this nowrap class in title (but what for a nowrap for title ?).
Lyr!C
